### PR TITLE
Fixed Fossil Ore not generating

### DIFF
--- a/common/src/main/resources/data/netherexp/worldgen/configured_feature/soul_sand_valley/fossil_ore.json
+++ b/common/src/main/resources/data/netherexp/worldgen/configured_feature/soul_sand_valley/fossil_ore.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:ore",
   "config": {
-    "size": 2,
+    "size": 3,
     "discard_chance_on_air_exposure": 0.2,
     "targets": [
       {
@@ -16,5 +16,3 @@
     ]
   }
 }
-
-


### PR DESCRIPTION
The minecraft wiki says following about ore spawn size: The maximum number of generated blocks for size 2 is 0 (paraphrased)

Fix: changed size to 3, with the maximum number of generated blocks now being 4

Fixes #6 