### PR TITLE
Fix Failing Refmap, Ectoplasm lang Regression.

### DIFF
--- a/src/main/resources/assets/netherexp/lang/en_us.json
+++ b/src/main/resources/assets/netherexp/lang/en_us.json
@@ -180,7 +180,7 @@
   "block.netherexp.suspicious_soul_sand": "Suspicious Soul Sand",
   "block.netherexp.soul_magma_block": "Soul Magma Block",
 
-  "fluid.netherexp.ectoplasm": "Ectoplasm",
+  "fluid_type.netherexp.ectoplasm": "Ectoplasm",
   "block.netherexp.ectoplasm": "Ectoplasm",
   "item.netherexp.ectoplasm_bucket": "Ectoplasm Bucket",
   "block.netherexp.black_ice": "Black Ice",

--- a/src/main/resources/assets/netherexp/lang/ru_ru.json
+++ b/src/main/resources/assets/netherexp/lang/ru_ru.json
@@ -178,7 +178,7 @@
   "block.netherexp.suspicious_soul_sand": "Подозрительный песок душ",
   "block.netherexp.soul_magma_block": "Магма душ",
 
-  "fluid.netherexp.ectoplasm": "Эктоплазма",
+  "fluid_type.netherexp.ectoplasm": "Эктоплазма",
   "block.netherexp.ectoplasm": "Эктоплазма",
   "item.netherexp.ectoplasm_bucket": "Ведро эктоплазмы",
   "block.netherexp.black_ice": "Чёрный лёд",

--- a/src/main/resources/mixins.netherexp.json
+++ b/src/main/resources/mixins.netherexp.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "net.jadenxgamer.netherexp.mixin",
-  "refmap": "untitled_ben10.refmap.json",
+  "refmap": "mixins.netherexp.refmap.json",
   "compatibilityLevel": "JAVA_17",
   "minVersion": "0.8",
   "plugin": "net.jadenxgamer.netherexp.mixin.JNEMixinPluginForge",


### PR DESCRIPTION
Wanted to go fix the texture issue I pointed out in #71 but happy to see that actually just fixed in dev. Seems the solution did cause a regression in the fluid name though so figured I'd pr that instead (:
And the build would currently crash in production as the mixin config points at a non-existent refmap.