### PR TITLE
Better Archeology Compatibility Fix (Issue #245)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,10 @@ dependencies {
     // For Dev Testing
     runtimeOnly fg.deobf("curse.maven:configured-457570:5180900") // Configured
     runtimeOnly fg.deobf("curse.maven:embeddium-908741:5681725") // Embeddium
-    //runtimeOnly fg.deobf("curse.maven:jade-324717:5876199") // Jade
+    // runtimeOnly fg.deobf("curse.maven:jade-324717:5876199") // Jade
+    // runtimeOnly fg.deobf("curse.maven:supermartijn642s-config-lib-438332:4715408") // SuperMartijn642's Config Lib
+    // runtimeOnly fg.deobf("curse.maven:yungs-api-421850:5769971") // YUNG's API
+    // runtimeOnly fg.deobf("curse.maven:better-archeology-835687:5693368") // Better Archeology
 
     // Example mod dependency with JEI - using fg.deobf() ensures the dependency is remapped to your development mappings
     // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime

--- a/src/main/java/net/jadenxgamer/netherexp/registry/block/custom/EctoSoulSandBlock.java
+++ b/src/main/java/net/jadenxgamer/netherexp/registry/block/custom/EctoSoulSandBlock.java
@@ -23,6 +23,7 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BrushItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.BlockGetter;
@@ -63,7 +64,7 @@ public class EctoSoulSandBlock extends Block {
         ItemStack itemStack = player.getItemInHand(hand);
         boolean salted = state.getValue(SALTED);
         if (!salted) {
-            if (itemStack.is(Items.BRUSH) && level.getBlockState(pos.above()).isAir()) {
+            if (itemStack.getItem() instanceof BrushItem && level.getBlockState(pos.above()).isAir()) {
                 level.playSound(player, pos, SoundEvents.BRUSH_SAND, SoundSource.BLOCKS, 1.0f, level.getRandom().nextFloat() * 0.4f + 0.8f);
                 level.playSound(player, pos, JNESoundEvents.ENTITY_WISP_AMBIENT.get(), SoundSource.BLOCKS, 0.5F, 1.0F);
                 if (!player.isCreative()) {


### PR DESCRIPTION
Fixed an issue where brushes from any mod (e.g., Better Archeology) now work with ecto soul sand. 
The brush simply needs to inherit from the BrushItem class.

---

I made this fix for version 1.20.1, but  it will work on any version of Minecraft that has the mod installed if you make the same change I made (it's just one line).
