### PR TITLE
Fix dedicated server crash: PetrifiedSwirlsBlockEntity#triggerEvent loads client-only class

### DIFF
--- a/src/main/java/net/jadenxgamer/netherexp/core/block/entity/PetrifiedSwirlsBlockEntity.java
+++ b/src/main/java/net/jadenxgamer/netherexp/core/block/entity/PetrifiedSwirlsBlockEntity.java
@@ -56,21 +56,20 @@ public class PetrifiedSwirlsBlockEntity extends BlockEntity {
 
     @Override
     public boolean triggerEvent(int id, int type) {
-        if (this.level != null && id == 1) {
-            switch (type) {
-                case 0 -> {
-                    PetrifiedSwirlsBlock.Client.petrificationParticle(level, level.random, getBlockPos());
-                    return true;
-                }
-                case 1 -> {
-                    PetrifiedSwirlsBlock.Client.unpetrifyParticle(level, level.random, getBlockPos());
-                    return true;
-                }
-                case 2 -> {
-                    PetrifiedSwirlsBlock.Client.attractToPetrifierParticle(level, level.random, getBlockPos());
-                    return true;
+        if (this.level != null && id == 1 && type >= 0 && type <= 2) {
+            // The particle helpers live in PetrifiedSwirlsBlock.Client, which is @OnlyIn(Dist.CLIENT).
+            // triggerEvent is dispatched on the server too (ServerLevel#blockEvent -> doBlockEvent),
+            // so touching that class server-side trips RuntimeDistCleaner and crashes dedicated servers.
+            // Only spawn particles on the client; on the server just acknowledge the event (return true)
+            // so it is still relayed to nearby clients.
+            if (this.level.isClientSide()) {
+                switch (type) {
+                    case 0 -> PetrifiedSwirlsBlock.Client.petrificationParticle(level, level.random, getBlockPos());
+                    case 1 -> PetrifiedSwirlsBlock.Client.unpetrifyParticle(level, level.random, getBlockPos());
+                    case 2 -> PetrifiedSwirlsBlock.Client.attractToPetrifierParticle(level, level.random, getBlockPos());
                 }
             }
+            return true;
         }
         return super.triggerEvent(id, type);
     }


### PR DESCRIPTION
Fixes #282.

### Problem

`PetrifiedSwirlsBlockEntity#triggerEvent` unconditionally calls the `PetrifiedSwirlsBlock.Client` particle helpers, which live in an `@OnlyIn(Dist.CLIENT)` nested class. But `triggerEvent` is dispatched **server-side** too — `PetrifiedSwirlsBlockEntity#tick` calls `ServerLevel#blockEvent(...)`, which runs `doBlockEvent` → `BlockEntity#triggerEvent` on the server to decide whether to relay the event to clients.

On a dedicated server this makes NeoForge's `RuntimeDistCleaner` refuse to load the client class, throwing:

```
java.lang.RuntimeException: Attempted to load class net/jadenxgamer/netherexp/core/block/PetrifiedSwirlsBlock$Client for invalid dist DEDICATED_SERVER
	at ...PetrifiedSwirlsBlockEntity.triggerEvent(PetrifiedSwirlsBlockEntity.java:66)
	at ...ServerLevel.doBlockEvent(ServerLevel.java:1215)
	at ...ServerLevel.tick(ServerLevel.java:382)
```

The whole server crashes during world tick, then crash-loops whenever the affected Nether chunk reloads. This is the same class of bug as the `ParticleRenderType` crash fixed in #269 — the new Petrified Swirls code is just missing the `level.isClientSide` guard.

### Fix

Gate the client-only particle calls behind `level.isClientSide()`. On the server, `triggerEvent` now simply returns `true` for the handled ids so the event is still broadcast to clients (where the particles actually render). Client behaviour is unchanged.

### Testing

Built against this branch (NeoForge 21.1.x, MC 1.21.1) and deployed to a dedicated server that was reliably crash-looping. Force-loaded the Nether chunks containing the Petrified Swirls blocks (which previously crashed the server within seconds) and let them tick their block events — server stayed up and healthy with no `RuntimeDistCleaner` exception and no crash report. Client-side particle calls are unchanged from the original code, just gated to the logical client.