### PR TITLE
Better Archeology Compatibility Fix (Issue #245)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,10 @@ repositories {
         name = "Terraformers"
         url = "https://maven.terraformersmc.com/releases/"
     }
+    maven {
+        name = "Modrinth Maven"
+        url = "https://api.modrinth.com/maven"
+    }
 
     maven { url 'https://jitpack.io' }
 
@@ -126,6 +130,11 @@ dependencies {
 
     compileOnly "top.theillusivec4.curios:curios-neoforge:$curios_version:api"
     runtimeOnly "top.theillusivec4.curios:curios-neoforge:$curios_version"
+
+    // These mods are not dependencies and are only used for testing
+    //runtimeOnly "maven.modrinth:resourceful-config:$resourceful_config_version"
+    //runtimeOnly "maven.modrinth:architectury-api:$architectury_api_version"
+    //runtimeOnly "maven.modrinth:better-archeology:$better_archeology_version"
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,3 +31,8 @@ lodestone_version = 1.21.1-1.8.2.525
 curios_version = 9.5.1+1.21.1
 elysium_version = 1.2.0-alpha.8
 biolith_version = 3.0.10
+
+# Non-Dependencies (testing)
+resourceful_config_version = 3.0.11
+architectury_api_version = 13.0.8+neoforge
+better_archeology_version = rp4lPDKI

--- a/src/main/java/net/jadenxgamer/netherexp/core/block/EctoSoulSandBlock.java
+++ b/src/main/java/net/jadenxgamer/netherexp/core/block/EctoSoulSandBlock.java
@@ -23,6 +23,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BrushItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
@@ -55,7 +56,7 @@ public class EctoSoulSandBlock extends SoulSandBlock {
 
     @Override
     protected ItemInteractionResult useItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hitResult) {
-        if (JNEConfigs.BRUSH_WISPS_OUT.get() && stack.is(Items.BRUSH) && level.getBlockState(pos.above()).isAir()) {
+        if (JNEConfigs.BRUSH_WISPS_OUT.get() && stack.getItem() instanceof BrushItem && level.getBlockState(pos.above()).isAir()) {
             level.playSound(null, pos, SoundEvents.BRUSH_SAND, SoundSource.BLOCKS, 1.0f, 1.0f);
             if (!player.getAbilities().instabuild) stack.hurtAndBreak(JNEConfigs.ECTO_SOUL_SAND_BRUSH_DAMAGE.get(), player, LivingEntity.getSlotForHand(hand));
             ParticleHelper.surroundBlockParticle(level, pos, ParticleTypes.SOUL);


### PR DESCRIPTION
Fixed an issue where brushes from any mod (e.g., Better Archeology) now work with ecto soul sand (the action of removing the Wisp).
Every item that inherits from the BrushItem class works.
Also added the Better Archaeology mod (and its libs) for runtime-only testing.


