### PR TITLE
Revert "Fix dedicated server crash: PetrifiedSwirlsBlockEntity#triggerEvent loads client-only class"

### DIFF
--- a/src/main/java/net/jadenxgamer/netherexp/core/block/entity/PetrifiedSwirlsBlockEntity.java
+++ b/src/main/java/net/jadenxgamer/netherexp/core/block/entity/PetrifiedSwirlsBlockEntity.java
@@ -56,20 +56,21 @@ public class PetrifiedSwirlsBlockEntity extends BlockEntity {
 
     @Override
     public boolean triggerEvent(int id, int type) {
-        if (this.level != null && id == 1 && type >= 0 && type <= 2) {
-            // The particle helpers live in PetrifiedSwirlsBlock.Client, which is @OnlyIn(Dist.CLIENT).
-            // triggerEvent is dispatched on the server too (ServerLevel#blockEvent -> doBlockEvent),
-            // so touching that class server-side trips RuntimeDistCleaner and crashes dedicated servers.
-            // Only spawn particles on the client; on the server just acknowledge the event (return true)
-            // so it is still relayed to nearby clients.
-            if (this.level.isClientSide()) {
-                switch (type) {
-                    case 0 -> PetrifiedSwirlsBlock.Client.petrificationParticle(level, level.random, getBlockPos());
-                    case 1 -> PetrifiedSwirlsBlock.Client.unpetrifyParticle(level, level.random, getBlockPos());
-                    case 2 -> PetrifiedSwirlsBlock.Client.attractToPetrifierParticle(level, level.random, getBlockPos());
+        if (this.level != null && id == 1) {
+            switch (type) {
+                case 0 -> {
+                    PetrifiedSwirlsBlock.Client.petrificationParticle(level, level.random, getBlockPos());
+                    return true;
+                }
+                case 1 -> {
+                    PetrifiedSwirlsBlock.Client.unpetrifyParticle(level, level.random, getBlockPos());
+                    return true;
+                }
+                case 2 -> {
+                    PetrifiedSwirlsBlock.Client.attractToPetrifierParticle(level, level.random, getBlockPos());
+                    return true;
                 }
             }
-            return true;
         }
         return super.triggerEvent(id, type);
     }


### PR DESCRIPTION
It has come to attention that the following PR was AI generated using Claude
and as such is being reverted. I do not condone nor support generative AI use in my personal projects, everything about JNE is 100% human made and I intend on keeping it that way.