### PR TITLE
Fix ticking exception when a block is placed without having an entity

### DIFF
--- a/src/main/java/net/jadenxgamer/netherexp/mixin/item/BlockItemMixin.java
+++ b/src/main/java/net/jadenxgamer/netherexp/mixin/item/BlockItemMixin.java
@@ -40,7 +40,7 @@ public abstract class BlockItemMixin {
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;consume(ILnet/minecraft/world/entity/LivingEntity;)V")
     )
     private void netherexp$preventShrinkWhenBetrayed(ItemStack instance, int amount, LivingEntity entity, Operation<Void> original) {
-        if (entity.hasEffect(JNEMobEffects.BETRAYED)) amount = 0;
+        if (entity != null && entity.hasEffect(JNEMobEffects.BETRAYED)) amount = 0;
         original.call(instance, amount, entity);
     }
 }


### PR DESCRIPTION
the preventShrinkWhenBetrayed method in BlockItemMixin can cause a ticking exception when a block is placed without having an entity. This causes a crash with Botania's Rannuncarpus (and probably some other things) since it attempts to place items dropped nearby without an entity.

The change simply makes sure the entity isn't null before trying to check if it has the betrayed effect.