### PR TITLE
Fix dedicated server crashes caused by client-only references in common code

### DIFF
--- a/src/main/java/net/jadenxgamer/netherexp/core/entity/Stampede.java
+++ b/src/main/java/net/jadenxgamer/netherexp/core/entity/Stampede.java
@@ -8,7 +8,6 @@ import net.jadenxgamer.netherexp.registry.JNECriteriaTriggers;
 import net.jadenxgamer.netherexp.registry.JNEItems;
 import net.jadenxgamer.netherexp.registry.JNESoundEvents;
 import net.jadenxgamer.netherexp.util.AdvancementGranter;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.BlockParticleOption;
 import net.minecraft.core.particles.ItemParticleOption;
@@ -682,11 +681,11 @@ public class Stampede extends PossessedMob implements NeutralMob, Saddleable, Pl
     private void playEatingAnimation() {
         if (this.getEatingTime() <= 0 || this.getEatingTime() % 5 != 0) return;
         var random = this.random;
-        Player player = Minecraft.getInstance().player;
-        if (player != null) this.level().playSound(null, this.blockPosition(), JNESoundEvents.STAMPEDE_EAT.get(), this.getSoundSource(),
+        if (!this.level().isClientSide()) return;
+
+        this.level().playSound(null, this.blockPosition(), JNESoundEvents.STAMPEDE_EAT.get(), this.getSoundSource(),
                 0.5f + 0.5f * random.nextInt(2), (random.nextFloat() - random.nextFloat()) * 0.2f + 1.0f);
 
-        if (!level().isClientSide) return;
         float degToRad = 0.017453292f;
         float pitchRad = -this.getXRot() * degToRad;
         float yawRad = -this.getYRot() * degToRad;

--- a/src/main/java/net/jadenxgamer/netherexp/core/item/SanctumCompassItem.java
+++ b/src/main/java/net/jadenxgamer/netherexp/core/item/SanctumCompassItem.java
@@ -37,6 +37,8 @@ import net.minecraft.world.item.ProjectileWeaponItem;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.CustomModelData;
 import net.minecraft.world.level.Level;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -175,6 +177,7 @@ public class SanctumCompassItem extends ProjectileWeaponItem {
         return true;
     }
 
+    @OnlyIn(Dist.CLIENT)
     public static void registerProperties() {
         ItemProperties.register(JNEItems.SANCTUM_COMPASS.get(),
                 ResourceLocation.withDefaultNamespace("angle"),

--- a/src/main/java/net/jadenxgamer/netherexp/event/JNEEvents.java
+++ b/src/main/java/net/jadenxgamer/netherexp/event/JNEEvents.java
@@ -11,6 +11,7 @@ import net.jadenxgamer.netherexp.core.entity.PortalGlow;
 import net.jadenxgamer.netherexp.core.entity.Stampede;
 import net.jadenxgamer.netherexp.core.misc.JNEBuiltinPacks;
 import net.jadenxgamer.netherexp.core.misc.JNECauldronInteractions;
+import net.jadenxgamer.netherexp.core.keys.JNETags;
 import net.jadenxgamer.netherexp.core.worldgen.JNESurfaceRules;
 import net.jadenxgamer.netherexp.registry.*;
 import net.jadenxgamer.netherexp.util.BlockCrackTracker;
@@ -166,6 +167,10 @@ public class JNEEvents {
     @SubscribeEvent
     public static void onLivingTick(EntityTickEvent.Post event) {
         if (!(event.getEntity() instanceof LivingEntity entity)) return;
-        BurnPalettesManager.handleLastFire(entity.level(), entity);
+        if (entity.level().isClientSide()) return;
+        if (entity.displayFireAnimation()) {
+            var state = entity.getInBlockState();
+            if (state.is(JNETags.Blocks.LAST_FIRE_SUPPORTED_BLOCKS)) entity.setData(JNEAttachmentTypes.LAST_FIRE, state.getBlock().builtInRegistryHolder().key().location());
+        } else entity.setData(JNEAttachmentTypes.LAST_FIRE, NetherExp.minecraftPath("fire"));
     }
 }


### PR DESCRIPTION
## What's wrong
The mod crashes on a **dedicated server** at startup/runtime with:

```
RuntimeDistCleaner: Attempted to load class net/minecraft/client/... for invalid dist DEDICATED_SERVER
```

Three spots in common (non-client) code referenced client-only classes, which is only tolerated on a client (singleplayer/integrated server).

## Changes

**1. `Stampede.java` — `playEatingAnimation()`**
- Removed `net.minecraft.client.Minecraft` import and `Minecraft.getInstance().player`.
- The method is now guarded with `if (!this.level().isClientSide()) return;` before playing the sound/particles, so it never runs on the server.

**2. `SanctumCompassItem.java` — `registerProperties()`**
- Annotated `@OnlyIn(Dist.CLIENT)`. It is only invoked from `JNEClientEvents.onClientSetup` (a `Dist.CLIENT` subscriber), so the reference is stripped safely on dedicated servers.

**3. `JNEEvents.java` — `onLivingTick()`**
- `BurnPalettesManager` is a client-only class (imports `Minecraft`/`RenderSystem`/`NativeImage`) but `handleLastFire()` contained pure server logic and was called from a common tick handler, loading the whole class on the server.
- Inlined the actual server-side logic (updating the `LAST_FIRE` attachment) directly in the handler and guarded with `entity.level().isClientSide()`. The client-only reload-listener registration stays untouched.

## Testing
- Builds successfully with `./gradlew build` on the `1.21.1` branch (NeoForge 21.1.230).
- Launched a dedicated server: mod loading completes, world loads, spawn area generates, and the server runs (`Done (…)!`) with no `RuntimeDistCleaner` crash.